### PR TITLE
:memo: Update Status.im open positions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Jobs and Tips for remote work
 - https://automattic.com/work-with-us/
 - https://www.toptal.com/careers
 - https://github.com/about/careers
-- https://status.im/open-positions.html
+- https://status.im/contribute/open_positions.html
 - https://mixmax.com/careers/
 - https://new.consensys.net/careers/
 - https://www.invisionapp.com/company#jobs


### PR DESCRIPTION
The link `https://status.im/open-positions.html` redirect to _not found page_, in this PR I have updated this to `https://status.im/contribute/open_positions.html` current link.